### PR TITLE
remove undesired attributes when exporting to_json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 log/*.log
 pkg/
 .DS_Store
+.byebug_history

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=353c6a501e63f1f23c4932392c4826207846216a2b42f9230fa4645b69027c27
+language: ruby
+rvm:
+  - 2.2
+  - 2.3
+  - 2.4
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+script:
+  - bundle exec rake
+after_script:
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ gemspec
 # To use debugger
 # gem 'debugger'
 gem 'rake'
+gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,44 @@ PATH
   remote: .
   specs:
     smoney (0.0.1)
+      activesupport
       json
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    byebug (9.0.6)
+    coderay (1.1.0)
+    concurrent-ruby (1.0.5)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
     json (2.1.0)
+    method_source (0.8.2)
     minitest (5.11.3)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
+      pry (~> 0.10)
     rake (12.3.1)
+    slop (3.6.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   minitest
+  pry-byebug
   rake
   smoney!
 

--- a/lib/railtie.rb
+++ b/lib/railtie.rb
@@ -1,4 +1,3 @@
-if defined? Rails
 module Smoney
   class Railtie < Rails::Railtie
     config.smoney = ActiveSupport::OrderedOptions.new

--- a/lib/railtie.rb
+++ b/lib/railtie.rb
@@ -1,3 +1,4 @@
+if defined? Rails
 module Smoney
   class Railtie < Rails::Railtie
     config.smoney = ActiveSupport::OrderedOptions.new

--- a/lib/smoney.rb
+++ b/lib/smoney.rb
@@ -26,6 +26,9 @@ module Smoney
   end
 end
 
+require "active_support"
+require "active_support/core_ext/string"
+require "railtie" if defined? Rails
 Dir.glob(__dir__ + "/smoney/entity/**/*.rb").each {|file| require file }
 Dir.glob(__dir__ + "/smoney/ext/**/*.rb").each {|file| require file }
 Dir.glob(__dir__ + "/smoney/http/**/*.rb").each {|file| require file }

--- a/lib/smoney.rb
+++ b/lib/smoney.rb
@@ -1,4 +1,4 @@
-require 'smoney/railtie' if defined?(Rails)
+require 'railtie' if defined?(Rails)
 require 'cgi'
 
 module Smoney
@@ -28,7 +28,6 @@ end
 
 require "active_support"
 require "active_support/core_ext/string"
-require "railtie" if defined? Rails
 Dir.glob(__dir__ + "/smoney/entity/**/*.rb").each {|file| require file }
 Dir.glob(__dir__ + "/smoney/ext/**/*.rb").each {|file| require file }
 Dir.glob(__dir__ + "/smoney/http/**/*.rb").each {|file| require file }

--- a/lib/smoney/entity/base.rb
+++ b/lib/smoney/entity/base.rb
@@ -48,7 +48,7 @@ module Smoney
       end
 
       def to_json
-        hash = @data
+        hash = @data.splice(self.class.attributes.keys)
         objects.map do |variable|
           object = instance_variable_get("@" + variable.to_s)
           hash[map_attribute variable.to_sym] = JSON.parse object.to_json if object

--- a/lib/smoney/entity/base.rb
+++ b/lib/smoney/entity/base.rb
@@ -48,7 +48,7 @@ module Smoney
       end
 
       def to_json
-        hash = @data.splice(self.class.attributes.keys)
+        hash = @data.slice(*self.class.attributes.keys.map(&:to_s))
         objects.map do |variable|
           object = instance_variable_get("@" + variable.to_s)
           hash[map_attribute variable.to_sym] = JSON.parse object.to_json if object

--- a/smoney.gemspec
+++ b/smoney.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "json"
+  s.add_dependency "activesupport"
   s.add_development_dependency "minitest"
 end

--- a/test/smoney/entity_test.rb
+++ b/test/smoney/entity_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class Smoney::EntityTest < Minitest::Test
+  def test_to_json_removes_unwanted_fields
+    address = Smoney::Address.from_data "unwanted" => "field", "street" => "21 Jump St", "zip_code" => "12345", "city" => "NY", "country" => "US"
+    assert_equal(address.to_json, "{\"street\":\"21 Jump St\",\"zip_code\":\"12345\",\"city\":\"NY\",\"country\":\"US\"}")
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,2 +1,5 @@
 require "minitest/autorun"
+require_relative "../lib/smoney"
+require "byebug"
+
 ENV["RAILS_ENV"] = "test"


### PR DESCRIPTION
When sending a POST request after fetching data from a GET request, we need attributes coming from GET that are not declared in our entities not to be sent back to API.